### PR TITLE
Split database models from monolith

### DIFF
--- a/extensions.py
+++ b/extensions.py
@@ -1,8 +1,17 @@
-from flask_sqlalchemy import SQLAlchemy
-from flask_migrate import Migrate
+import os
+
+from flask_apscheduler import APScheduler
 from flask_login import LoginManager
 from flask_mail import Mail
-from flask_apscheduler import APScheduler
+from flask_migrate import Migrate
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import create_engine
+from sqlalchemy.engine.base import Engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm.session import Session
+
+import models  # noqa: F401  # Required for model discovery
+from models.base import Base
 
 """
 Flask extensions module.
@@ -10,8 +19,20 @@ Initializes and configures Flask extensions used throughout the application.
 These extensions will be attached to the Flask app in the app.py file.
 """
 
+
 # Create extension instances
 db = SQLAlchemy()
+
+engine: Engine = create_engine(
+    os.getenv("SQLALCHEMY_DATABASE_URI", "sqlite:///instance/expenses.db")
+)
+session: Session = sessionmaker(bind=engine)()
+
+
+def init_db() -> None:
+    Base.metadata.create_all(engine)
+
+
 migrate = Migrate()
 login_manager = LoginManager()
 mail = Mail()

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,32 @@
+"""Provides model classes."""
+
+from .account import Account
+from .budget import Budget
+from .category import Category, CategoryMapping, CategorySplit
+from .currency import Currency
+from .expense import Expense
+from .gocardless import GoCardlessSettings
+from .group import Group
+from .recurring import IgnoredRecurringPattern, RecurringExpense
+from .settlement import Settlement
+from .simplefin import SimpleFinSettings
+from .tag import Tag
+from .user import User
+
+__all__: list[str] = [
+    "Account",
+    "Budget",
+    "Category",
+    "CategoryMapping",
+    "CategorySplit",
+    "Currency",
+    "Expense",
+    "GoCardlessSettings",
+    "Group",
+    "IgnoredRecurringPattern",
+    "RecurringExpense",
+    "Settlement",
+    "SimpleFinSettings",
+    "Tag",
+    "User",
+]

--- a/models/account.py
+++ b/models/account.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+from typing import TYPE_CHECKING, ClassVar, Optional
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import (
+    Mapped,
+    backref,
+    mapped_column,
+    relationship,
+)
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from models import Currency, User
+
+
+class Account(Base):
+    """Store account information."""
+
+    __tablename__: ClassVar[str] = "accounts"
+
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    type: Mapped[str] = mapped_column(
+        String(50), nullable=False
+    )  # checking, savings, credit, etc.
+    institution: Mapped[str] = mapped_column(String(100), nullable=True)
+    user_id: Mapped[str] = mapped_column(
+        String(120),
+        ForeignKey("users.id", name="fk_account_user"),
+        nullable=False,
+    )
+
+    currency_code: Mapped[Optional[str]] = mapped_column(
+        String(3),
+        ForeignKey("currencies.code", name="fk_account_currency"),
+        default=None,
+    )
+
+    last_sync: Mapped[Optional[datetime]] = mapped_column(default=None)
+    import_source: Mapped[Optional[str]] = mapped_column(
+        String(50), default=None
+    )
+    # Relationships
+    user: Mapped[Optional["User"]] = relationship(
+        "User", backref=backref("accounts", lazy=True), default=None
+    )
+
+    currency: Mapped[Optional["Currency"]] = relationship(
+        "Currency", backref=backref("accounts", lazy=True), default=None
+    )
+
+    external_id: Mapped[Optional[str]] = mapped_column(
+        String(200), nullable=True, default=None
+    )
+    status: Mapped[Optional[str]] = mapped_column(
+        String(20), nullable=True, default=None
+    )  # Add this line too for 'active'/'inactive' status
+
+    balance: Mapped[float] = mapped_column(default=0.0)
+
+    def __repr__(self) -> str:
+        """Return string representation of account information."""
+        return f"<Account {self.name} ({self.type})>"

--- a/models/base.py
+++ b/models/base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass
+
+
+class Base(MappedAsDataclass, DeclarativeBase):
+    """Basic SQLAlchemy base class for models."""

--- a/models/budget.py
+++ b/models/budget.py
@@ -1,0 +1,232 @@
+from datetime import datetime, timedelta
+from datetime import timezone as tz
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
+
+from sqlalchemy import ForeignKey, String, literal, or_
+from sqlalchemy.orm import (
+    Mapped,
+    backref,
+    mapped_column,
+    relationship,
+)
+from sqlalchemy.sql.elements import ColumnElement
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from models import Category, CategorySplit, Expense, User
+
+
+class Budget(Base):
+    """Store budget information."""
+
+    __tablename__: ClassVar[str] = "budgets"
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    user_id: Mapped[str] = mapped_column(
+        String(120), ForeignKey("users.id"), nullable=False
+    )
+    category_id: Mapped[int] = mapped_column(
+        ForeignKey("categories.id"), nullable=False
+    )
+    name: Mapped[Optional[str]] = mapped_column(
+        String(100)
+    )  # Optional custom name for the budget
+    amount: Mapped[float] = mapped_column(nullable=False)
+    period: Mapped[str] = mapped_column(
+        String(20), nullable=False
+    )  # 'weekly', 'monthly', 'yearly'
+    include_subcategories: Mapped[bool] = mapped_column(default=True)
+    start_date: Mapped[datetime] = mapped_column(
+        nullable=False, default=datetime.now(tz.utc)
+    )
+    is_recurring: Mapped[bool] = mapped_column(default=True)
+    active: Mapped[bool] = mapped_column(default=True)
+    created_at: Mapped[datetime] = mapped_column(default=datetime.now(tz.utc))
+    updated_at: Mapped[datetime] = mapped_column(
+        default=datetime.now(tz.utc), onupdate=datetime.now(tz.utc)
+    )
+
+    # Relationships
+    user: Mapped[Optional["User"]] = relationship(
+        "User", backref=backref("budgets", lazy=True), default=None
+    )
+    category: Mapped[Optional["Category"]] = relationship(
+        "Category", backref=backref("budgets", lazy=True), default=None
+    )
+
+    transaction_types: Mapped[str] = mapped_column(
+        String(100), default="expense"
+    )  # comma-separated list of types to include
+
+    def get_current_period_dates(self):
+        """Get start and end dates for the current budget period."""
+        today: datetime = datetime.now(tz.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+
+        if self.period == "weekly":
+            # Start of the week (Monday)
+            start_of_week: datetime = today - timedelta(days=today.weekday())
+            end_of_week: datetime = start_of_week + timedelta(
+                days=6, hours=23, minutes=59, seconds=59
+            )
+            return start_of_week, end_of_week
+
+        if self.period == "monthly":
+            # Start of the month
+            start_of_month = today.replace(day=1)
+            # End of the month
+            if today.month == 12:
+                end_of_month = today.replace(
+                    year=today.year + 1, month=1, day=1
+                ) - timedelta(seconds=1)
+            else:
+                end_of_month = today.replace(
+                    month=today.month + 1, day=1
+                ) - timedelta(seconds=1)
+            return start_of_month, end_of_month
+
+        if self.period == "yearly":
+            # Start of the year
+            start_of_year = today.replace(month=1, day=1)
+            # End of the year
+            end_of_year = today.replace(
+                year=today.year + 1, month=1, day=1
+            ) - timedelta(seconds=1)
+            return start_of_year, end_of_year
+
+        # Default to current day
+        return today, today.replace(hour=23, minute=59, second=59)
+
+    def calculate_spent_amount(self):
+        """Calculate spent amount in this budget's category during the period."""
+        start_date: datetime
+        end_date: datetime
+        start_date, end_date = self.get_current_period_dates()
+
+        # Base query: find all expenses in the relevant date range for this user
+
+        subcategories: list[Category] = []
+        if self.include_subcategories:
+            # If this is a parent category, include subcategories
+            subcategories = Category.query.filter_by(
+                parent_id=self.category_id
+            ).all()
+            subcategory_ids: list[int] = [subcat.id for subcat in subcategories]
+
+            # Include the parent category itself and all subcategories
+            category_filter: ColumnElement[bool] = or_(
+                Expense.category_id == self.category_id,
+                Expense.category_id.in_(subcategory_ids)
+                if subcategory_ids
+                else literal(False),
+            )
+        else:
+            # Only include this specific category
+            category_filter = Expense.category_id == self.category_id
+
+        # Get all expenses that match our criteria
+        expenses: list[Expense] = Expense.query.filter(
+            Expense.user_id == self.user_id,
+            Expense.date >= start_date,
+            Expense.date <= end_date,
+            category_filter,
+        ).all()
+
+        # Calculate the total spent for these expenses
+        total_spent = 0.0
+
+        # Process each expense to calculate the user's portion
+        for expense in expenses:
+            # If the expense has category splits, we need a different approach
+            if expense.has_category_splits:
+                # Handle category splits separately
+                continue
+
+            # Get the split information for this expense
+            splits: dict[str, Any] = expense.calculate_splits()
+
+            # If the user is the payer and not in the splits, add their portion
+            if expense.paid_by == self.user_id and (
+                not expense.split_with
+                or self.user_id not in expense.split_with.split(",")
+            ):
+                total_spent += splits["payer"]["amount"]
+            else:
+                # Check if the current user is in the splits
+                for split in splits["splits"]:
+                    if split["email"] == self.user_id:
+                        total_spent += split["amount"]
+                        break
+
+        # Handle expenses with category splits
+        if self.include_subcategories:
+            category_ids: list[int] = [self.category_id] + [
+                subcat.id for subcat in subcategories
+            ]
+        else:
+            category_ids = [self.category_id]
+
+        # Find all category splits for relevant categories
+        category_splits = (
+            CategorySplit.query.join(
+                Expense, CategorySplit.expense_id == Expense.id
+            )
+            .filter(
+                Expense.user_id == self.user_id,
+                Expense.date >= start_date,
+                Expense.date <= end_date,
+                CategorySplit.category_id.in_(category_ids),
+            )
+            .all()
+        )
+
+        # Process each category split
+        for cat_split in category_splits:
+            expense = Expense.query.get(cat_split.expense_id)
+            if not expense:
+                continue
+
+            # Get the split information for this expense
+            splits = expense.calculate_splits()
+
+            # Calculate the user's share of this category split
+            if expense.paid_by == self.user_id and (
+                not expense.split_with
+                or self.user_id not in expense.split_with.split(",")
+            ):
+                # User is the payer and not in splits - add their portion
+                if expense.amount > 0:
+                    user_ratio = splits["payer"]["amount"] / expense.amount
+                    total_spent += cat_split.amount * user_ratio
+            else:
+                # Check if the user is in the splits
+                for split in splits["splits"]:
+                    if split["email"] == self.user_id:
+                        if expense.amount > 0:
+                            user_ratio = split["amount"] / expense.amount
+                            total_spent += cat_split.amount * user_ratio
+                        break
+
+        return total_spent
+
+    def get_remaining_amount(self):
+        """Calculate remaining budget amount."""
+        return self.amount - self.calculate_spent_amount()
+
+    def get_progress_percentage(self):
+        """Return progress percentage."""
+        spent = self.calculate_spent_amount()
+        if self.amount <= 0:
+            return 100  # Avoid division by zero
+        percentage = (spent / self.amount) * 100
+        return min(percentage, 100)  # Cap at 100%
+
+    def get_status(self):
+        """Return the budget status: 'under', 'approaching', 'over'."""
+        percentage = self.get_progress_percentage()
+        if percentage >= 100:
+            return "over"
+        if percentage >= 80:
+            return "approaching"
+        return "under"

--- a/models/category.py
+++ b/models/category.py
@@ -1,0 +1,129 @@
+from datetime import datetime
+from datetime import timezone as tz
+from typing import TYPE_CHECKING, ClassVar, Optional
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import (
+    Mapped,
+    backref,
+    mapped_column,
+    relationship,
+)
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from models import Expense, User
+
+
+class Category(Base):
+    """Stores category information."""
+
+    __tablename__: ClassVar[str] = "categories"
+
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    name: Mapped[str] = mapped_column(String(50), nullable=False)
+
+    user_id: Mapped[str] = mapped_column(
+        String(120), ForeignKey("users.id"), nullable=False
+    )
+
+    # Relationships
+    user: Mapped[Optional["User"]] = relationship(
+        "User", backref=backref("categories", lazy=True), default=None
+    )
+    parent_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("categories.id"), default=None
+    )
+    parent: Mapped[Optional["Category"]] = relationship(
+        "Category",
+        remote_side=[id],
+        backref=backref("subcategories", lazy=True),
+        default=None,
+    )
+    expenses: Mapped[Optional["Expense"]] = relationship(
+        "Expense", backref=backref("category", lazy=True), default=None
+    )
+
+    icon: Mapped[str] = mapped_column(
+        String(50), default="fa-tag"
+    )  # FontAwesome icon name
+    color: Mapped[str] = mapped_column(String(20), default="#6c757d")
+
+    is_system: Mapped[bool] = mapped_column(
+        default=False
+    )  # System categories can't be deleted
+    created_at: Mapped[datetime] = mapped_column(default=datetime.now(tz.utc))
+
+    def __repr__(self) -> str:
+        """Return string representation of category information."""
+        return f"<Category: {self.name}>"
+
+
+class CategorySplit(Base):
+    """Stores category split information."""
+
+    __tablename__: ClassVar[str] = "category_splits"
+
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    expense_id: Mapped[int] = mapped_column(
+        ForeignKey("expenses.id"), nullable=False
+    )
+    category_id: Mapped[int] = mapped_column(
+        ForeignKey("categories.id"), nullable=False
+    )
+    amount: Mapped[float] = mapped_column(nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(
+        String(200), nullable=True, default=None
+    )
+
+    # Relationships
+    expense: Mapped[Optional["Expense"]] = relationship(
+        "Expense",
+        backref=backref("category_splits", cascade="all, delete-orphan"),
+        default=None,
+    )
+    category: Mapped[Optional["Category"]] = relationship(
+        "Category", backref=backref("splits", lazy=True), default=None
+    )
+
+
+class CategoryMapping(Base):
+    """Stores information about a category mapping."""
+
+    __tablename__: ClassVar[str] = "category_mappings"
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    user_id: Mapped[str] = mapped_column(
+        String(120), ForeignKey("users.id"), nullable=False
+    )
+    keyword: Mapped[str] = mapped_column(String(100), nullable=False)
+    category_id: Mapped[int] = mapped_column(
+        ForeignKey("categories.id"), nullable=False
+    )
+
+    # Relationships
+    user: Mapped[Optional["User"]] = relationship(
+        "User", backref=backref("category_mappings", lazy=True), default=None
+    )
+    category: Mapped[Optional["Category"]] = relationship(
+        "Category", backref=backref("mappings", lazy=True), default=None
+    )
+
+    is_regex: Mapped[bool] = mapped_column(
+        default=False
+    )  # Whether the keyword is a regex pattern
+    priority: Mapped[int] = mapped_column(
+        default=0
+    )  # Higher priority mappings take precedence
+    match_count: Mapped[int] = mapped_column(
+        default=0
+    )  # How many times this mapping has been used
+    active: Mapped[bool] = mapped_column(default=True)
+    created_at: Mapped[datetime] = mapped_column(default=datetime.now(tz.utc))
+
+    def __repr__(self) -> str:
+        """Return string representation of category mapping information."""
+        return (
+            f"<CategoryMapping: '{self.keyword}' → "
+            f"{self.category.name if self.category else self.category_id}>"
+        )

--- a/models/currency.py
+++ b/models/currency.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from datetime import timezone as tz
+from typing import ClassVar
+
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class Currency(Base):
+    """Stores currency information."""
+
+    __tablename__: ClassVar[str] = "currencies"
+
+    code: Mapped[str] = mapped_column(
+        String(3), primary_key=True
+    )  # ISO 4217 currency code (e.g., USD, EUR, GBP)
+    name: Mapped[str] = mapped_column(String(50), nullable=False)
+    symbol: Mapped[str] = mapped_column(String(5), nullable=False)
+    rate_to_base: Mapped[float] = mapped_column(
+        nullable=False, default=1.0
+    )  # Exchange rate to base currency
+    is_base: Mapped[bool] = mapped_column(
+        default=False
+    )  # Whether this is the base currency
+    last_updated: Mapped[datetime] = mapped_column(default=datetime.now(tz.utc))
+
+    def __repr__(self) -> str:
+        """Return string representation of Currency information."""
+        return f"{self.code} ({self.symbol})"

--- a/models/expense.py
+++ b/models/expense.py
@@ -1,0 +1,408 @@
+from datetime import datetime
+from datetime import timezone as tz
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
+
+from sqlalchemy import ForeignKey, String, Text
+from sqlalchemy.orm import (
+    Mapped,
+    backref,
+    mapped_column,
+    relationship,
+)
+
+from tables import expense_tags
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from models import Account, Currency, Tag, User
+
+
+class Expense(Base):
+    """Store expense information."""
+
+    __tablename__: ClassVar[str] = "expenses"
+
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    description: Mapped[str] = mapped_column(String(200), nullable=False)
+    amount: Mapped[float] = mapped_column(nullable=False)
+
+    card_used: Mapped[str] = mapped_column(String(150), nullable=False)
+    split_method: Mapped[str] = mapped_column(
+        String(20), nullable=False
+    )  # 'equal', 'custom', 'percentage'
+
+    paid_by: Mapped[str] = mapped_column(String(50), nullable=False)
+    user_id: Mapped[str] = mapped_column(
+        String(120), ForeignKey("users.id"), nullable=False
+    )
+
+    transaction_type: Mapped[str] = mapped_column(
+        String(20), server_default="expense"
+    )  # 'expense', 'income', 'transfer'
+
+    split_value: Mapped[Optional[float]] = mapped_column(
+        default=None
+    )  # deprecated - kept for backward compatibility
+
+    group_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("groups.id"), nullable=True, default=None
+    )
+    split_with: Mapped[Optional[str]] = mapped_column(
+        String(500), nullable=True, default=None
+    )  # Comma-separated list of user IDs
+    split_details: Mapped[Optional[str]] = mapped_column(
+        Text, nullable=True, default=None
+    )  # JSON string storing custom split values for each user
+    recurring_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("recurring_expenses.id"), nullable=True, default=None
+    )
+
+    # Add these fields to your existing Expense class:
+    currency_code: Mapped[Optional[str]] = mapped_column(
+        String(3), ForeignKey("currencies.code"), nullable=True, default=None
+    )
+    original_amount: Mapped[Optional[float]] = mapped_column(
+        nullable=True, default=None
+    )  # Amount in original currency
+    category_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("categories.id"), nullable=True, default=None
+    )
+
+    # imports
+    account_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("accounts.id", name="fk_expense_account"),
+        nullable=True,
+        default=None,
+    )
+
+    tags: Mapped[list["Tag"]] = relationship(
+        "Tag",
+        secondary=expense_tags,
+        lazy="subquery",
+        backref=backref("expenses", lazy=True),
+        default_factory=list,
+    )
+
+    currency: Mapped[Optional["Currency"]] = relationship(
+        "Currency", backref=backref("expenses", lazy=True), default=None
+    )
+    external_id: Mapped[Optional[str]] = mapped_column(
+        String(200), nullable=True, default=None
+    )  # For tracking external transaction IDs
+    import_source: Mapped[Optional[str]] = mapped_column(
+        String(50), nullable=True, default=None
+    )  # 'csv', 'simplefin', 'manual'
+
+    account: Mapped[Optional["Account"]] = relationship(
+        "Account",
+        foreign_keys=[account_id],
+        backref=backref("expenses", lazy=True),
+        default=None,
+    )
+
+    # For transfers, we need a destination account
+    destination_account_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("accounts.id", name="fk_destination_account"),
+        nullable=True,
+        default=None,
+    )
+    destination_account: Mapped[Optional["Account"]] = relationship(
+        "Account",
+        foreign_keys=[destination_account_id],
+        backref=backref("incoming_transfers", lazy=True),
+        default=None,
+    )
+
+    # Add to Expense class:
+    has_category_splits: Mapped[bool] = mapped_column(default=False)
+
+    date: Mapped[datetime] = mapped_column(
+        nullable=False, default=datetime.now(tz.utc)
+    )
+
+    @property
+    def is_income(self) -> bool:
+        """Return whether this is an income."""
+        return self.transaction_type == "income"
+
+    @property
+    def is_transfer(self) -> bool:
+        """Return whether this is a transfer."""
+        return self.transaction_type == "transfer"
+
+    @property
+    def is_expense(self) -> bool:
+        """Return whether this is an expense."""
+        return (
+            self.transaction_type == "expense" or self.transaction_type is None
+        )
+
+    def calculate_splits(self) -> dict[str, Any]:  # noqa: C901, PLR0912, PLR0915
+        """Calculate the split for each person.
+
+        :return: Dictionary containing payer and split information
+        :rtype: dict
+        """
+        # Get the user who paid
+        payer: User | None = User.query.filter_by(id=self.paid_by).first()
+        if not payer:
+            return {}
+        payer = cast(User, payer)
+        payer_name: str = payer.name if payer else "Unknown"
+        payer_email: str = payer.id
+
+        # Get all people this expense is split with
+        split_with_ids = self.split_with.split(",") if self.split_with else []
+        split_users = []
+
+        for user_id in split_with_ids:
+            user = User.query.filter_by(id=user_id.strip()).first()
+            if user:
+                split_users.append(
+                    {"id": user.id, "name": user.name, "email": user.id}
+                )
+
+        # Handle case where original_amount is None by using amount
+        original_amount = (
+            self.original_amount
+            if self.original_amount is not None
+            else self.amount
+        )
+
+        # Set up result structure with both base and original currency
+        result = {
+            "payer": {
+                "name": payer_name,
+                "email": payer_email,
+                "amount": 0,  # Base currency amount
+                "original_amount": original_amount,  # Original amount
+                "currency_code": self.currency_code,  # Original currency code
+            },
+            "splits": [],
+        }
+
+        # Parse split details if available
+        split_details = {}
+        if self.split_details:
+            try:
+                if isinstance(self.split_details, str):
+                    import json
+
+                    split_details = json.loads(self.split_details)
+                elif isinstance(self.split_details, dict):
+                    split_details = self.split_details
+            except Exception as e:
+                # Log the error or handle it as appropriate
+                print(
+                    f"Error parsing split_details for expense {self.id}: {str(e)}"
+                )
+                split_details = {}
+
+        if self.split_method == "equal":
+            # Count participants (include payer only if not already in splits)
+            total_participants = len(split_users) + (
+                1 if self.paid_by not in split_with_ids else 0
+            )
+
+            # Equal splits among all participants
+            per_person = (
+                self.amount / total_participants
+                if total_participants > 0
+                else 0
+            )
+            per_person_original = (
+                original_amount / total_participants
+                if total_participants > 0
+                else 0
+            )
+
+            # Assign payer's portion (only if they're not already in the splits)
+            if self.paid_by not in split_with_ids:
+                result["payer"]["amount"] = per_person
+            else:
+                result["payer"]["amount"] = 0
+
+            # Assign everyone else's portion
+            for user in split_users:
+                result["splits"].append(
+                    {
+                        "name": user["name"],
+                        "email": user["email"],
+                        "amount": per_person,
+                        "original_amount": per_person_original,
+                        "currency_code": self.currency_code,
+                    }
+                )
+
+        elif self.split_method == "percentage":
+            # Use per-user percentages if available in split_details
+            if (
+                split_details
+                and isinstance(split_details, dict)
+                and split_details.get("type") == "percentage"
+            ):
+                percentages = split_details.get("values", {})
+                total_assigned = 0
+                total_original_assigned = 0
+
+                # Calculate payer's amount if specified
+                payer_percent = float(percentages.get(self.paid_by, 0))
+                payer_amount = (self.amount * payer_percent) / 100
+                payer_original_amount = (original_amount * payer_percent) / 100
+
+                result["payer"]["amount"] = (
+                    payer_amount if self.paid_by not in split_with_ids else 0
+                )
+                total_assigned += (
+                    payer_amount if self.paid_by not in split_with_ids else 0
+                )
+                total_original_assigned += (
+                    payer_original_amount
+                    if self.paid_by not in split_with_ids
+                    else 0
+                )
+
+                # Calculate each user's portion based on their percentage
+                for user in split_users:
+                    user_percent = float(percentages.get(user["id"], 0))
+                    user_amount = (self.amount * user_percent) / 100
+                    user_original_amount = (
+                        original_amount * user_percent
+                    ) / 100
+
+                    result["splits"].append(
+                        {
+                            "name": user["name"],
+                            "email": user["email"],
+                            "amount": user_amount,
+                            "original_amount": user_original_amount,
+                            "currency_code": self.currency_code,
+                        }
+                    )
+                    total_assigned += user_amount
+                    total_original_assigned += user_original_amount
+
+                # Validate total (handle rounding errors)
+                if abs(total_assigned - self.amount) > 0.01:
+                    difference = self.amount - total_assigned
+                    if result["splits"]:
+                        result["splits"][-1]["amount"] += difference
+                    elif result["payer"]["amount"] > 0:
+                        result["payer"]["amount"] += difference
+
+            else:
+                # Backward compatibility mode
+                payer_percentage = (
+                    self.split_value if self.split_value is not None else 0
+                )
+                payer_amount = (self.amount * payer_percentage) / 100
+                payer_original_amount = (
+                    original_amount * payer_percentage
+                ) / 100
+
+                result["payer"]["amount"] = (
+                    payer_amount if self.paid_by not in split_with_ids else 0
+                )
+
+                # Split remainder equally
+                remaining = self.amount - result["payer"]["amount"]
+                remaining_original = original_amount - payer_original_amount
+                per_person = remaining / len(split_users) if split_users else 0
+                per_person_original = (
+                    remaining_original / len(split_users) if split_users else 0
+                )
+
+                for user in split_users:
+                    result["splits"].append(
+                        {
+                            "name": user["name"],
+                            "email": user["email"],
+                            "amount": per_person,
+                            "original_amount": per_person_original,
+                            "currency_code": self.currency_code,
+                        }
+                    )
+
+        elif self.split_method == "custom":
+            # Use per-user custom amounts if available in split_details
+            if (
+                split_details
+                and isinstance(split_details, dict)
+                and split_details.get("type") in ["amount", "custom"]
+            ):
+                amounts = split_details.get("values", {})
+                total_assigned = 0
+                total_original_assigned = 0
+
+                # Set payer's amount if specified
+                payer_amount = float(amounts.get(self.paid_by, 0))
+                # For original amount, scale by the same proportion
+                payer_ratio = payer_amount / self.amount if self.amount else 0
+                payer_original_amount = original_amount * payer_ratio
+
+                result["payer"]["amount"] = (
+                    payer_amount if self.paid_by not in split_with_ids else 0
+                )
+                total_assigned += (
+                    payer_amount if self.paid_by not in split_with_ids else 0
+                )
+
+                # Set each user's amount
+                for user in split_users:
+                    user_amount = float(amounts.get(user["id"], 0))
+                    # Scale original amount by same proportion
+                    user_ratio = user_amount / self.amount if self.amount else 0
+                    user_original_amount = original_amount * user_ratio
+
+                    result["splits"].append(
+                        {
+                            "name": user["name"],
+                            "email": user["email"],
+                            "amount": user_amount,
+                            "original_amount": user_original_amount,
+                            "currency_code": self.currency_code,
+                        }
+                    )
+                    total_assigned += user_amount
+
+                # Validate total (handle rounding errors)
+                if abs(total_assigned - self.amount) > 0.01:
+                    difference = self.amount - total_assigned
+                    if result["splits"]:
+                        result["splits"][-1]["amount"] += difference
+                    elif result["payer"]["amount"] > 0:
+                        result["payer"]["amount"] += difference
+            else:
+                # Backward compatibility mode
+                payer_amount = (
+                    self.split_value if self.split_value is not None else 0
+                )
+                # Calculate the ratio of payer amount to total
+                payer_ratio = payer_amount / self.amount if self.amount else 0
+                payer_original_amount = original_amount * payer_ratio
+
+                result["payer"]["amount"] = (
+                    payer_amount if self.paid_by not in split_with_ids else 0
+                )
+
+                # Split remainder equally
+                remaining = self.amount - result["payer"]["amount"]
+                remaining_original = original_amount - payer_original_amount
+                per_person = remaining / len(split_users) if split_users else 0
+                per_person_original = (
+                    remaining_original / len(split_users) if split_users else 0
+                )
+
+                for user in split_users:
+                    result["splits"].append(
+                        {
+                            "name": user["name"],
+                            "email": user["email"],
+                            "amount": per_person,
+                            "original_amount": per_person_original,
+                            "currency_code": self.currency_code,
+                        }
+                    )
+
+        return result

--- a/models/gocardless.py
+++ b/models/gocardless.py
@@ -1,0 +1,57 @@
+from datetime import datetime as dt
+from datetime import timezone as tz
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    ForeignKey,
+    String,
+    Text,
+)
+from sqlalchemy.orm import (
+    Mapped,
+    backref,
+    mapped_column,
+    relationship,
+)
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from models import User
+
+
+class GoCardlessSettings(Base):
+    """Stores GoCardless connection settings for a user."""
+
+    __tablename__ = "GoCardless"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[str] = mapped_column(
+        String(120), ForeignKey("users.id"), nullable=False, unique=True
+    )
+    access_token: Mapped[Text] = mapped_column(Text, nullable=False)
+    refresh_token: Mapped[str] = mapped_column(Text, nullable=False)
+
+    last_sync: Mapped[dt] = mapped_column(nullable=True)
+
+    temp_accounts: Mapped[str] = mapped_column(Text, nullable=True)
+
+    # Relationship with User
+    user: Mapped["User"] = relationship(
+        "User", backref=backref("GoCardless", uselist=False, lazy=True)
+    )
+
+    access_token_expiration: Mapped[dt] = mapped_column(default=dt.now(tz.utc))
+    refresh_token_expiration: Mapped[dt] = mapped_column(default=dt.now(tz.utc))
+    enabled: Mapped[bool] = mapped_column(default=True)
+    sync_frequency: Mapped[str] = mapped_column(
+        String(20), default="daily"
+    )  # 'daily', 'weekly', etc.
+    created_at: Mapped[dt] = mapped_column(default=dt.now(tz.utc))
+    updated_at: Mapped[dt] = mapped_column(
+        default=dt.now(tz.utc),
+        onupdate=dt.now(tz.utc),
+    )
+
+    def __repr__(self):
+        """Return string representation of the GoCardless settings."""
+        return f"<GoCardless settings for user {self.user_id}>"

--- a/models/group.py
+++ b/models/group.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+from datetime import timezone as tz
+from typing import TYPE_CHECKING, ClassVar
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import (
+    Mapped,
+    backref,
+    mapped_column,
+    relationship,
+)
+
+from tables import group_users
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from models import Expense, User
+
+
+class Group(Base):
+    """Stores group information and settings."""
+
+    __tablename__: ClassVar[str] = "groups"
+
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    description: Mapped[str] = mapped_column(String(200))
+    created_by: Mapped[str] = mapped_column(
+        String(120), ForeignKey("users.id"), nullable=False
+    )
+    members: Mapped[list["User"]] = relationship(
+        "User",
+        secondary=group_users,
+        lazy="subquery",
+        backref=backref("groups", lazy=True),
+        default_factory=list,
+    )
+    expenses: Mapped[list["Expense"]] = relationship(
+        "Expense",
+        backref="group",
+        lazy=True,
+        default_factory=list,
+    )
+    created_at: Mapped[datetime] = mapped_column(default=datetime.now(tz.utc))

--- a/models/recurring.py
+++ b/models/recurring.py
@@ -1,0 +1,192 @@
+from datetime import datetime
+from datetime import timezone as tz
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
+
+from sqlalchemy import ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.orm import (
+    Mapped,
+    backref,
+    mapped_column,
+    relationship,
+)
+
+from models import Expense
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from models import Account, Category, Currency, Group, User
+
+
+class RecurringExpense(Base):
+    """Store recurring expense information."""
+
+    __tablename__: ClassVar[str] = "recurring_expenses"
+
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    description: Mapped[str] = mapped_column(String(200), nullable=False)
+    amount: Mapped[float] = mapped_column(nullable=False)
+    card_used: Mapped[str] = mapped_column(String(150), nullable=False)
+    split_method: Mapped[str] = mapped_column(
+        String(20), nullable=False
+    )  # 'equal', 'custom', 'percentage'
+
+    paid_by: Mapped[str] = mapped_column(String(50), nullable=False)
+    user_id: Mapped[str] = mapped_column(
+        String(120), ForeignKey("users.id"), nullable=False
+    )
+
+    # Recurring specific fields
+    frequency: Mapped[str] = mapped_column(
+        String(20), nullable=False
+    )  # 'daily', 'weekly', 'monthly', 'yearly'
+    start_date: Mapped[datetime] = mapped_column(nullable=False)
+
+    group_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("groups.id"), default=None
+    )
+    split_with: Mapped[Optional[str]] = mapped_column(
+        String(500), default=None
+    )  # Comma-separated list of user IDs
+
+    split_value: Mapped[Optional[float]] = mapped_column(default=None)
+    split_details: Mapped[Optional[str]] = mapped_column(
+        Text, default=None
+    )  # JSON string
+
+    end_date: Mapped[Optional[datetime]] = mapped_column(
+        default=None
+    )  # Optional end date
+    last_created: Mapped[Optional[datetime]] = mapped_column(
+        default=None
+    )  # Track last created instance
+
+    # Relationships
+    user: Mapped[Optional["User"]] = relationship(
+        "User", backref=backref("recurring_expenses", lazy=True), default=None
+    )
+    group: Mapped[Optional["Group"]] = relationship(
+        "Group", backref=backref("recurring_expenses", lazy=True), default=None
+    )
+    expenses: Mapped[list["Expense"]] = relationship(
+        "Expense",
+        backref=backref("recurring_source", lazy=True),
+        foreign_keys="Expense.recurring_id",
+        default_factory=list,
+    )
+    currency_code: Mapped[Optional[str]] = mapped_column(
+        String(3), ForeignKey("currencies.code"), default=None
+    )
+    original_amount: Mapped[Optional[float]] = mapped_column(
+        default=None
+    )  # Amount in original currency
+    currency: Mapped[Optional["Currency"]] = relationship(
+        "Currency",
+        backref=backref("recurring_expenses", lazy=True),
+        default=None,
+    )
+    category_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("categories.id"), default=None
+    )
+    category: Mapped[Optional["Category"]] = relationship(
+        "Category",
+        backref=backref("recurring_expenses", lazy=True),
+        default=None,
+    )
+    account_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("accounts.id", name="fk_recurring_account"),
+        default=None,
+    )
+    account: Mapped[Optional["Account"]] = relationship(
+        "Account",
+        foreign_keys=[account_id],
+        backref=backref("recurring_expenses", lazy=True),
+        default=None,
+    )
+
+    # For transfers
+    destination_account_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("accounts.id", name="fk_recurring_destination"), default=None
+    )
+    destination_account: Mapped[Optional["Account"]] = relationship(
+        "Account",
+        foreign_keys=[destination_account_id],
+        backref=backref("recurring_incoming_transfers", lazy=True),
+        default=None,
+    )
+    # Transaction type and account fields
+    transaction_type: Mapped[str] = mapped_column(
+        String(20), default="expense"
+    )  # 'expense', 'income', 'transfer'
+    active: Mapped[bool] = mapped_column(default=True)
+
+    def create_expense_instance(self, for_date: datetime | None = None):
+        """Create a single expense instance from this recurring template."""
+        if for_date is None:
+            for_date = datetime.now(tz.utc)
+        # Copy data to create a new expense
+        expense: Any = Expense(
+            description=self.description,
+            amount=self.amount,
+            date=for_date,
+            card_used=self.card_used,
+            split_method=self.split_method,
+            split_value=self.split_value,
+            split_details=self.split_details,
+            paid_by=self.paid_by,
+            user_id=self.user_id,
+            group_id=self.group_id,
+            split_with=self.split_with,
+            category_id=self.category_id,
+            recurring_id=self.id,
+            transaction_type=self.transaction_type,
+            account_id=self.account_id,
+            destination_account_id=self.destination_account_id
+            if self.transaction_type == "transfer"
+            else None,
+            currency_code=self.currency_code,
+            original_amount=self.original_amount,
+        )
+
+        # Update the last created date
+        self.last_created = for_date
+
+        return expense
+
+
+class IgnoredRecurringPattern(Base):
+    """Store patterns of recurring transactions, a user has chosen to ignore."""
+
+    __tablename__: ClassVar[str] = "ignored_recurring_patterns"
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    user_id: Mapped[str] = mapped_column(
+        String(120), ForeignKey("users.id"), nullable=False
+    )
+    pattern_key: Mapped[str] = mapped_column(
+        String(255), nullable=False
+    )  # Unique pattern identifier
+    description: Mapped[str] = mapped_column(
+        String(200), nullable=False
+    )  # For reference
+    amount: Mapped[float] = mapped_column(nullable=False)
+    frequency: Mapped[str] = mapped_column(String(20), nullable=False)
+    ignore_date: Mapped[datetime] = mapped_column(
+        nullable=False, default=datetime.now(tz.utc)
+    )
+
+    # Relationship with User
+    user: Mapped[Optional["User"]] = relationship(
+        "User", backref=backref("ignored_patterns", lazy=True), default=None
+    )
+
+    # Ensure user can't ignore the same pattern twice
+    __table_args__: tuple[UniqueConstraint] = (
+        UniqueConstraint("user_id", "pattern_key"),
+    )
+
+    def __repr__(self) -> str:
+        """Return string representation of ignored pattern information."""
+        return (
+            f"<IgnoredPattern: {self.description} ({self.amount}) - "
+            f"{self.frequency}>"
+        )

--- a/models/settlement.py
+++ b/models/settlement.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from datetime import timezone as tz
+from typing import TYPE_CHECKING, ClassVar, Optional
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import (
+    Mapped,
+    backref,
+    mapped_column,
+    relationship,
+)
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from models import User
+
+
+class Settlement(Base):
+    """Stores settlement information."""
+
+    __tablename__: ClassVar[str] = "settlements"
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    payer_id: Mapped[str] = mapped_column(
+        String(120), ForeignKey("users.id"), nullable=False
+    )
+    receiver_id: Mapped[str] = mapped_column(
+        String(120), ForeignKey("users.id"), nullable=False
+    )
+    amount: Mapped[float] = mapped_column(nullable=False)
+
+    # Relationships
+    payer: Mapped[Optional["User"]] = relationship(
+        "User",
+        foreign_keys=[payer_id],
+        backref=backref("settlements_paid", lazy=True),
+        default=None,
+    )
+    receiver: Mapped[Optional["User"]] = relationship(
+        "User",
+        foreign_keys=[receiver_id],
+        backref=backref("settlements_received", lazy=True),
+        default=None,
+    )
+
+    date: Mapped[datetime] = mapped_column(
+        nullable=False, default=datetime.now(tz.utc)
+    )
+    description: Mapped[str] = mapped_column(
+        String(200), nullable=True, default="Settlement"
+    )

--- a/models/simplefin.py
+++ b/models/simplefin.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from datetime import timezone as tz
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, backref, mapped_column, relationship
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from models import User
+
+
+class SimpleFinSettings(Base):
+    """Stores SimpleFin connection settings for a user."""
+
+    __tablename__ = "SimpleFin"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[str] = mapped_column(
+        String(120), ForeignKey("users.id"), nullable=False, unique=True
+    )
+    access_url: Mapped[str] = mapped_column(
+        Text, nullable=False
+    )  # Encoded/encrypted access URL
+    last_sync: Mapped[datetime] = mapped_column(nullable=True)
+    enabled: Mapped[bool] = mapped_column(default=True)
+    sync_frequency: Mapped[str] = mapped_column(
+        String(20), default="daily"
+    )  # 'daily', 'weekly', etc.
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        default=datetime.now(tz.utc), onupdate=datetime.now(tz.utc)
+    )
+    temp_accounts: Mapped[Optional[str]] = mapped_column(default=None)
+    # Relationship with User
+    user: Mapped[Optional["User"]] = relationship(
+        "User",
+        backref=backref("SimpleFin", uselist=False, lazy=True),
+        default=None,
+    )
+
+    def __repr__(self) -> str:
+        """Return string representation of SimpleFin settings."""
+        return f"<SimpleFin settings for user {self.user_id}>"

--- a/models/tag.py
+++ b/models/tag.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from datetime import timezone as tz
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import (
+    Mapped,
+    backref,
+    mapped_column,
+    relationship,
+)
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from models import User
+
+
+class Tag(Base):
+    """Store tag information."""
+
+    __tablename__ = "tags"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(50), nullable=False, unique=True)
+    user_id: Mapped[str] = mapped_column(
+        String(120), ForeignKey("users.id"), nullable=False
+    )
+
+    # Relationship
+    user: Mapped["User"] = relationship(
+        "User", backref=backref("tags", lazy=True)
+    )
+
+    color: Mapped[str] = mapped_column(
+        String(20), default="#6c757d"
+    )  # Default color gray
+
+    created_at: Mapped[datetime] = mapped_column(default=datetime.now(tz.utc))

--- a/models/user.py
+++ b/models/user.py
@@ -1,0 +1,112 @@
+import secrets
+from datetime import datetime, timedelta
+from datetime import timezone as tz
+from typing import TYPE_CHECKING, ClassVar, Optional
+
+from flask_login import UserMixin
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import (
+    Mapped,
+    backref,
+    mapped_column,
+    relationship,
+)
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from models import Group
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from models import Currency, Expense, Group
+
+
+class User(UserMixin, Base):
+    """Stores user information and settings."""
+
+    __tablename__: ClassVar[str] = "users"
+
+    id: Mapped[str] = mapped_column(
+        String(120), primary_key=True
+    )  # Using email as ID
+
+    name: Mapped[str] = mapped_column(String(100))
+
+    password_hash: Mapped[Optional[str]] = mapped_column(
+        String(256), default=None
+    )
+    reset_token: Mapped[Optional[str]] = mapped_column(
+        String(100), default=None
+    )
+    reset_token_expiry: Mapped[Optional[datetime]] = mapped_column(
+        nullable=True, default=None
+    )
+    expenses: Mapped[Optional["Expense"]] = relationship(
+        "Expense", backref="user", lazy=True, default=None
+    )
+    default_currency_code: Mapped[Optional[str]] = mapped_column(
+        String(3), ForeignKey("currencies.code"), default=None
+    )
+    default_currency: Mapped[Optional["Currency"]] = relationship(
+        "Currency", backref=backref("users", lazy=True), default=None
+    )
+    created_groups: Mapped[Optional["Group"]] = relationship(
+        "Group",
+        backref="creator",
+        lazy=True,
+        foreign_keys=[Group.created_by],
+        default=None,
+    )
+    # OIDC related fields
+    oidc_id: Mapped[Optional[str]] = mapped_column(
+        String(255), index=True, unique=True, default=None
+    )
+    oidc_provider: Mapped[Optional[str]] = mapped_column(
+        String(50), default=None
+    )
+    last_login: Mapped[Optional[datetime]] = mapped_column(default=None)
+
+    user_color: Mapped[str] = mapped_column(String(7), default="#15803d")
+
+    is_admin: Mapped[bool] = mapped_column(default=False)
+    monthly_report_enabled: Mapped[bool] = mapped_column(default=True)
+    created_at: Mapped[datetime] = mapped_column(default=datetime.now(tz.utc))
+    timezone: Mapped[str] = mapped_column(
+        String(50), nullable=True, default="UTC"
+    )
+
+    def set_password(self, password):
+        """Hash password and store it."""
+        self.password_hash = generate_password_hash(
+            password, method="pbkdf2:sha256"
+        )
+
+    def check_password(self, password):
+        """Check password against stored password hash."""
+        # No password set
+        if not self.password_hash:
+            return False
+        try:
+            return check_password_hash(self.password_hash, password)
+        except ValueError:
+            return False
+
+    def generate_reset_token(self):
+        """Generate a password reset token that expires in 1 hour."""
+        self.reset_token = secrets.token_urlsafe(32)
+        self.reset_token_expiry = datetime.now(tz.utc) + timedelta(hours=1)
+        return self.reset_token
+
+    def verify_reset_token(self, token):
+        """Verify if the provided token is valid and not expired."""
+        if not self.reset_token or self.reset_token != token:
+            return False
+        return not (
+            not self.reset_token_expiry
+            or self.reset_token_expiry < datetime.now(tz.utc)
+        )
+
+    def clear_reset_token(self):
+        """Clear the reset token and expiry after use."""
+        self.reset_token = "None"
+        self.reset_token_expiry = datetime.now(tz.utc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 flask==2.2.5 
-flask-sqlalchemy==2.5.1 
+flask-sqlalchemy==3.1.1 
 flask-login==0.6.3 
 flask-migrate==4.1.0 
 flask-mail==0.10.0 
 python-dotenv==1.0.1 
 gunicorn==23.0.0 
-sqlalchemy==1.4.54 
+sqlalchemy==2.0.40 
 werkzeug==2.2.3 
 psycopg2-binary==2.9.9 
 requests==2.28.2  

--- a/tables.py
+++ b/tables.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, ForeignKey, Integer, String, Table
+
+from models.base import Base
+
+group_users = Table(
+    "group_users",
+    Base.metadata,
+    Column("group_id", Integer, ForeignKey("groups.id"), primary_key=True),
+    Column("user_id", String(120), ForeignKey("users.id"), primary_key=True),
+)
+
+expense_tags = Table(
+    "expense_tags",
+    Base.metadata,
+    Column("expense_id", Integer, ForeignKey("expenses.id"), primary_key=True),
+    Column("tag_id", Integer, ForeignKey("tags.id"), primary_key=True),
+)


### PR DESCRIPTION
This PR splits all database models and tables from the monolith into their own files. Models are found in models folder while tables are found in tables.py.
To make the models work properly, I modified them to use the new SQLAlchemy 2.0 orm style. Due to this modification, flask_sqlalchemy and sqlalchemy had to be updated to their newest versions in the requirements.txt.

The database models no longer subclass db.Model from flask_sqlalchemy, but now subclass the vanilla SQLAlchemy classes MappedAsDataclass and DeclarativeBase (combined into a single Base class), which enable full IDE support and offer more flexibility.