### PR TITLE
Fix: fallback to DEFAULT_CURRENCY when currency_code is missing or blank

### DIFF
--- a/app.py
+++ b/app.py
@@ -7043,13 +7043,18 @@ def simplefin_add_accounts():
                 accounts_added += 1
                 account_obj = existing_account
             else:
+                # Get currency code from account or default, ensuring it's not empty
+                currency_code = sf_account.get('currency_code')
+                if not currency_code or currency_code.strip() == '':
+                    currency_code = default_currency
+                
                 # Create new account with custom values
                 new_account = Account(
                     name=sf_account.get('name'),  # Custom name from form
                     type=sf_account.get('type'),  # Custom type from form
                     institution=sf_account.get('institution'),
                     balance=sf_account.get('balance', 0),
-                    currency_code=sf_account.get('currency_code', default_currency),
+                    currency_code=currency_code,
                     user_id=current_user.id,
                     import_source='simplefin',
                     external_id=sf_account.get('id'),


### PR DESCRIPTION
Resolves issue #104 - Importing SimpleFin accounts with missing currency_code fails with FK_violation

Previously, importing accounts from SimpleFin that lacked a `currency_code` would trigger a foreign‐key constraint violation on `accounts.currency_code`, causing the entire import to fail. This commit ensures that:

- We call `sf_account.get('currency_code')` instead of indexing directly.
- If the result is `None`, empty, or only whitespace, we assign `default_currency` (e.g. “USD”).
- All downstream logic receives a guaranteed, non‐empty `currency_code`, so the INSERT can’t blow up.

With this change, any account missing currency info will silently—and safely—default to your configured currency, and the import batch completes without errors.

No behavior changes for accounts that already specify a valid currency.

---
Please let me know if any tweaks need to be made, or you have any other comments!